### PR TITLE
Properly handle interleaving of slots and parts

### DIFF
--- a/katex fun.jl
+++ b/katex fun.jl
@@ -115,14 +115,17 @@ begin
 	#	x = Meta.parse("\"" * _x * "\"")
  	#	tex(x)
 	#end
-	function tex(x::Expr)
-		@assert x.head === :string
-		SlottedLaTeX
-		quote
-			SlottedLaTeX(
-				parts = $(x.args[1:2:end]),
-				slots = [$(esc.(x.args[2:2:end])...)],
-			)
+	function tex(ex::Expr)
+		@assert ex.head === :string
+		parts = String[ex.args[1] isa String ? ex.args[1] : "\\hspace{0pt}"]
+		slots = Any[]
+		for x in ex.args[2:end]
+			if x isa String			
+				all(==(' '), x) ? push!(parts, "\\hspace{0pt}") : push!(parts, x)
+			else
+				length(parts) != length(slots) + 1 && push!(parts, "\\hspace{0pt}")
+				push!(slots, x)
+			end
 		end
 	end
 	function tex(x::String)

--- a/katex fun.jl
+++ b/katex fun.jl
@@ -117,8 +117,13 @@ begin
 	#end
 	function tex(ex::Expr)
 		@assert ex.head === :string
-		parts = String[ex.args[1] isa String ? ex.args[1] : "\\hspace{0pt}"]
-		slots = Any[]
+		if ex.args[1] isa String
+			parts = String[ex.args[1]]
+			slots = Any[]
+		else
+			parts = ["\\hspace{0pt}"]
+			slots = [ex.args[1]]
+		end
 		for x in ex.args[2:end]
 			if x isa String			
 				all(==(' '), x) ? push!(parts, "\\hspace{0pt}") : push!(parts, x)
@@ -126,6 +131,15 @@ begin
 				length(parts) != length(slots) + 1 && push!(parts, "\\hspace{0pt}")
 				push!(slots, x)
 			end
+		end
+		if length(slots) == length(parts)
+			push!(parts, "\\hspace{0pt}")
+		end
+		quote
+			SlottedLaTeX(
+				parts = $parts,
+				slots = [$(esc.(slots)...)],
+			)
 		end
 	end
 	function tex(x::String)


### PR DESCRIPTION
A mentioned in https://github.com/fonsp/disorganised-mess/pull/2#issuecomment-857965402, there are some edge cases that weren't properly handled in constructing the slots and parts if each interpolation wasn't surrounded by strings. This ended up being trickier than I thought' it'd be, but I believe it works now:

![image](https://user-images.githubusercontent.com/29157027/121576216-67236a00-c9e5-11eb-85df-fae75c5707fd.png)
